### PR TITLE
Fixed JPA issue while resurrecting BandwidthRestrictionsController

### DIFF
--- a/src/main/java/org/webcurator/domain/HeatmapDAOImpl.java
+++ b/src/main/java/org/webcurator/domain/HeatmapDAOImpl.java
@@ -63,7 +63,7 @@ public class HeatmapDAOImpl extends HibernateDaoSupport implements HeatmapDAO {
 					public Object doInHibernate(Session session) {
 						Query query = session
 								.getNamedQuery(HeatmapConfig.QRY_GET_CONFIG_BY_OID);
-						query.setLong(0, oid);
+						query.setLong(1, oid);
 						return query.uniqueResult();
 					}
 				});


### PR DESCRIPTION
This change is tiny but it is required by the PR https://github.com/WebCuratorTool/webcurator-webapp/pull/15 in webcurator-webapp.

Note: I had an issue with deleting and then recreating bandwidth restrictions: I got duplicate key errors, because the current value in the table ID_GENERATOR was too low. After basically doing this:

update ID_GENERATOR set IG_VALUE=(select max(BR_OID) from BANDWIDTH_RESTRICTIONS) where IG_TYPE='Bandwidth';

deleting and recreating worked fine again. Hopefully this was just my local dev db being broken.