### PR TITLE
Fixed infinate loop issues about target<==>group reference.

### DIFF
--- a/src/main/java/org/webcurator/core/targets/GroupEventPropagator.java
+++ b/src/main/java/org/webcurator/core/targets/GroupEventPropagator.java
@@ -144,6 +144,16 @@ public class GroupEventPropagator {
 	 * @param propagate True to propagate scheduling; otherwise false.
 	 */
 	public void runEventChain(TargetGroup ancestor, boolean propagate) {
+		Map<Object,Object> duplicateValidator=new HashMap<>();
+		runEventChainInternal(ancestor, propagate, duplicateValidator);
+		duplicateValidator.clear();
+	}
+	private void runEventChainInternal(TargetGroup ancestor, boolean propagate, final Map<Object,Object> duplicateValidator) {
+		if(duplicateValidator.containsKey(ancestor)){
+			return;
+		}else{
+			duplicateValidator.put(ancestor, ancestor);
+		}
 		addUpdatedGroup(ancestor);
 		
 		for(AbstractTarget member: members) {
@@ -187,7 +197,7 @@ public class GroupEventPropagator {
 		
 		Set<GroupMember> parents = ancestor.getParents();
 		for(GroupMember gm: parents) {
-			runEventChain(gm.getParent(), propagate);
+			runEventChainInternal(gm.getParent(), propagate, duplicateValidator);
 		}		
 	}
 

--- a/src/main/java/org/webcurator/core/targets/MembersRemovedEventPropagator.java
+++ b/src/main/java/org/webcurator/core/targets/MembersRemovedEventPropagator.java
@@ -151,6 +151,16 @@ public class MembersRemovedEventPropagator {
 	 * @param propagate True to propagate scheduling; otherwise false.
 	 */
 	private void recurseUp(TargetGroup ancestor, boolean propagate) {
+		Map<Object,Object> duplicateValidator=new HashMap<>();
+		duplicateValidator.clear();
+	}
+	private void recurseUpInternal(TargetGroup ancestor, boolean propagate, final Map<Object,Object> duplicateValidator) {
+		if (duplicateValidator.containsKey(ancestor)){
+			return;
+		}else{
+			duplicateValidator.put(ancestor, ancestor);
+		}
+
 		addUpdatedGroup(ancestor);
 		
 		// Scheduling must be propagated when the target group is
@@ -167,7 +177,7 @@ public class MembersRemovedEventPropagator {
 		
 		Set<GroupMember> parents = ancestor.getParents();
 		for(GroupMember gm: parents) {
-			recurseUp(gm.getParent(), propagate);
+			recurseUpInternal(gm.getParent(), propagate, duplicateValidator);
 		}		
 	}
 

--- a/src/main/java/org/webcurator/core/targets/MembersRemovedEventPropagator.java
+++ b/src/main/java/org/webcurator/core/targets/MembersRemovedEventPropagator.java
@@ -76,7 +76,7 @@ public class MembersRemovedEventPropagator {
 	 * @param targetManager The TargetManager to use
 	 * @param instanceManager The InstanceManager to use.
 	 * @param parent The parent that the member was added to.
-	 * @param member The AbstractTarget removed.
+	 * @param item The AbstractTarget removed.
 	 */
 	public MembersRemovedEventPropagator(TargetManager targetManager, TargetInstanceManager instanceManager, TargetGroup parent, AbstractTarget item) {
 		this(targetManager, instanceManager, parent, new LinkedList<AbstractTarget>());
@@ -152,6 +152,7 @@ public class MembersRemovedEventPropagator {
 	 */
 	private void recurseUp(TargetGroup ancestor, boolean propagate) {
 		Map<Object,Object> duplicateValidator=new HashMap<>();
+		recurseUpInternal(ancestor,propagate,duplicateValidator);
 		duplicateValidator.clear();
 	}
 	private void recurseUpInternal(TargetGroup ancestor, boolean propagate, final Map<Object,Object> duplicateValidator) {

--- a/src/main/java/org/webcurator/domain/TargetInstanceDAOImpl.java
+++ b/src/main/java/org/webcurator/domain/TargetInstanceDAOImpl.java
@@ -825,10 +825,10 @@ public class TargetInstanceDAOImpl extends HibernateDaoSupport implements Target
 		}
 		private void collectSchedules(AbstractTarget aTarget) {
 			Map<Object,Object> duplicateValidator=new HashMap<>();
-			collectSchedulesInterval(aTarget, duplicateValidator);
+			collectSchedulesInternal(aTarget, duplicateValidator);
 			duplicateValidator.clear();
 		}
-		private void collectSchedulesInterval(AbstractTarget aTarget, Map<Object,Object> duplicateValidator) {
+		private void collectSchedulesInternal(AbstractTarget aTarget, Map<Object,Object> duplicateValidator) {
 			if(duplicateValidator.containsKey(aTarget)){
 				return;
 			}else{
@@ -839,7 +839,7 @@ public class TargetInstanceDAOImpl extends HibernateDaoSupport implements Target
 
 			// Get all the schedules from parents.
 			for(GroupMember gm: aTarget.getParents()) {
-				collectSchedulesInterval(gm.getParent(), duplicateValidator);
+				collectSchedulesInternal(gm.getParent(), duplicateValidator);
 			}
 			
 		}

--- a/src/main/java/org/webcurator/domain/model/core/GroupMember.java
+++ b/src/main/java/org/webcurator/domain/model/core/GroupMember.java
@@ -71,7 +71,7 @@ public class GroupMember {
 	@JoinColumn(name = "GM_PARENT_ID", foreignKey = @ForeignKey(name = "FK_GM_PARENT_ID"))
 	private TargetGroup parent = null;
 	/** The child */
-	@ManyToOne
+	@ManyToOne(cascade = CascadeType.REFRESH)
 	@JoinColumn(name = "GM_CHILD_ID", foreignKey = @ForeignKey(name = "FK_GM_CHILD_ID"))
 	private AbstractTarget child = null;
 


### PR DESCRIPTION
If a Group is refered by a Target or a Group Member include Targets, the infinate loop issues will open when deleting refered instances and an stackoverflow exception happen.
Several methods cause the infinate loop issues. Please see the details in change log.